### PR TITLE
pass opts to gulp tag to be able change cwd for example

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(opts) {
     var json = JSON.parse(file.contents.toString()),
     	tag = opts.prefix+json[opts.key]
     gutil.log('Tagging as: '+gutil.colors.cyan(tag))
-    git.tag(tag, 'tagging as '+tag)
+    git.tag(tag, 'tagging as '+tag, opts)
     cb(null, file)
   }
 


### PR DESCRIPTION
Hey!
Thanks for your useful plugin!
Could you please approve this pull request? 
I want to support version bumping in bower(bower rely on tagging). In [my project](https://github.com/lapanoid/gulp-webpack-seed) I manage distrs as gitsubmodule, so I need to pass cwd like that:

``` js
gulp.task('ololo', function(){
    return gulp.src('./bower.json',  { cwd: './dist' })
        .pipe(bump({type: 'patch'}))
        .pipe(gulp.dest('./',{ cwd: './dist' }))
        .pipe(git.commit('bumps package version',{cwd: './dist'}))
        .pipe(filter('bower.json'))
        .pipe(tag_version({cwd: './dist'}));
});
```
