### PR TITLE
Issue #6: Git reset the bump commit when the tag already exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var map = require('map-stream'),
   gutil = require('gulp-util'),
-  git = require('gulp-git')
+  git = require('gulp-git'),
+  gift = require('gift');
 
 module.exports = function(opts) {
   if(!opts) opts = {}
@@ -16,7 +17,33 @@ module.exports = function(opts) {
     var json = JSON.parse(file.contents.toString()),
     	tag = opts.prefix+json[opts.key]
     gutil.log('Tagging as: '+gutil.colors.cyan(tag))
-    git.tag(tag, 'tagging as '+tag, opts)
+
+    // gift is a full-fledge git plugin
+    var APP_DIR = process.env.PWD;
+    var repo = gift(APP_DIR);
+
+    // Retrieve all the existing tags
+    repo.tags(function(err, tags) {
+      // Collect their names
+      var tagNames = tags.map(function(tag) {
+         return tag.name;
+      });
+
+      // If it does not exist, we can tag safely.
+      if (tagNames.indexOf(tag) < 0) {
+        git.tag(tag, 'tagging as '+tag, opts);
+
+      } else {
+        // Revert the "bump" commit because the command would fail.
+        gutil.log("Tag " + gutil.colors.cyan(tag) + " exists! Revering commit...");
+        repo.reset("HEAD^", function(err) {
+          if (err) {
+            return cb(new Error(err));
+          }
+        });
+      }
+    });
+
     cb(null, file)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tag-version",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tag git repository with current package version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
   "author": "Cezar \"ikari\" Pokorski <git@ikari.pl>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "map-stream": "~0.1.0",
+    "gift": "^0.4.3-1",
+    "gulp-git": "~0.3.6",
     "gulp-util": "~2.2.14",
-    "gulp-git": "~0.3.6"
+    "map-stream": "~0.1.0"
   },
   "devDependencies": {
     "gulp-bump": "~0.1.7",


### PR DESCRIPTION
This is performed by using the git module "gift" and not issuing
a git tag if it exists. That way, this fixes #6 properly.

https://github.com/notatestuser/gift#reporesettreeish-options-callback

After this point, we just reset HEAD^.

*	modified:   index.js
- Implementing the steps to get the git repo, and the list of tags

*	modified:   package.json
- Bumping the version manually to 1.1.1.