### PR TITLE
#10 Gulp callback fired too early

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,7 @@ module.exports = function(opts) {
     var tag = opts.prefix+version
     var label = opts.label.replace('%t', tag)
     gutil.log('Tagging as: '+gutil.colors.cyan(tag))
-    git.tag(tag, label, opts)
-    cb(null, file)
+    git.tag(tag, label, opts, cb)
   }
 
   return map(modifyContents)


### PR DESCRIPTION
moves gulp callback to git.tag so it is fired after tagging is finished