### PR TITLE
core: remove deprecated gulp-util and use original library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var map = require('map-stream'),
-  gutil = require('gulp-util'),
+  log = require('fancy-log'),
+  colors = require('ansi-colors'),
   git = require('gulp-git')
 
 /**
@@ -28,7 +29,7 @@ module.exports = function(opts) {
     }
     var tag = opts.prefix+version
     var label = opts.label.replace('%t', tag)
-    gutil.log('Tagging as: '+gutil.colors.cyan(tag))
+    log('Tagging as: '+colors.cyan(tag))
     git.tag(tag, label, opts, cb)
   }
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   "author": "Cezar \"ikari\" Pokorski <git@ikari.pl>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "map-stream": "~0.1.0",
-    "gulp-util": "~2.2.14",
-    "gulp-git": "~0.3.6"
+    "ansi-colors": "~1.0.1",
+    "fancy-log": "~1.3.2",
+    "gulp-git": "^2.4.2",
+    "map-stream": "~0.1.0"
   },
   "devDependencies": {
+    "gulp": "~3.6.0",
     "gulp-bump": "~0.1.7",
     "gulp-filter": "~0.4.0",
-    "gulp-prompt": "~0.1.1",
-    "gulp": "~3.6.0",
-    "gulp-git": "~0.3.6"
+    "gulp-prompt": "~0.1.1"
   }
 }


### PR DESCRIPTION
Hi,

Since `gulp-util` has been deprecated, this PR replace `gulp-util` with alternative individual modules. Please see: https://github.com/gulpjs/gulp-util